### PR TITLE
Fix Node 18 support in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '18.x'
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Changed
 - [AI-Agent: ai.github.codex] Migrated ESLint to flat config and updated security workflow checkout (2025-07-18)
+- [AI-Agent: ai.github.codex] Set Node.js version to 18.x in CI and enforced Node >=18 via package.json engines (2025-07-18)
 
 ### Fixed
 - [CI/CD-Agent: github-actions-bot] Workflow permissions and ESLint config adjustments (2025-07-18)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "plasmode",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "lint": "eslint modules/**/*.js tests/**/*.js",
     "lint:py": "pylint modules/**/*.py tests/**/*.py",
@@ -15,7 +18,6 @@
     "eslint-plugin-security": "^1.7.1",
     "eslint-plugin-no-secrets": "^1.0.5",
     "globals": "^16.0.0",
-    "jest": "^29.6.0",
     "jest": "^30.0.4",
     "semantic-release": "^21.0.7"
   }


### PR DESCRIPTION
## Summary
- set actions/setup-node to use Node 18.x
- add `engines` field to package.json and clean duplicate jest entry
- document CI update in CHANGELOG

## Testing
- `npm run lint`
- `npm test`
- `npm run test:py`
- `npm run validate:modules`


------
https://chatgpt.com/codex/tasks/task_e_687a6d2159bc8328a255a79133212ed3